### PR TITLE
fix: update schemas

### DIFF
--- a/models/keep3r_network/keep3r_network_keeper_work.sql
+++ b/models/keep3r_network/keep3r_network_keeper_work.sql
@@ -26,7 +26,16 @@
       ) }}
     UNION
     SELECT
-      *,
+  contract_address,
+  _credit,
+  evt_block_number,
+  evt_block_time,
+  evt_index,
+  evt_tx_hash,
+  _gasLeft,
+  _job,
+  _keeper,
+  _payment,
       'ethereum' as blockchain
     FROM
       {{ source(
@@ -35,7 +44,16 @@
       ) }}
       UNION
     SELECT
-      *,
+  contract_address,
+  _credit,
+  evt_block_number,
+  evt_block_time,
+  evt_index,
+  evt_tx_hash,
+  _gasLeft,
+  _job,
+  _keeper,
+  _payment,
       'optimism' as blockchain
     FROM
       {{ source(
@@ -44,7 +62,16 @@
       ) }}
       UNION
     SELECT
-      *,
+  contract_address,
+  _credit,
+  evt_block_number,
+  evt_block_time,
+  evt_index,
+  evt_tx_hash,
+  _gasLeft,
+  _job,
+  _keeper,
+  _payment,
       'polygon' as blockchain
     FROM
       {{ source(


### PR DESCRIPTION
event schemas have changed but only for some chains, causing the spell to fail

# Thank you for contributing to Spellbook!
Please refer to the top of the `readme` in the root of Spellbook to learn how to contribute to Spellbook on DuneSQL.